### PR TITLE
Fix token variable name in home automation example

### DIFF
--- a/home_assistant/README.md
+++ b/home_assistant/README.md
@@ -20,13 +20,13 @@ Create a `.env` file in the project root (or set these variables in your environ
 
 | Variable                | Description                                                      |
 |-------------------------|------------------------------------------------------------------|
-| `HOMEAUTOMAITON_TOKEN`  | Your Home Assistant long-lived access token                      |
+| `HOMEAUTOMATION_TOKEN`  | Your Home Assistant long-lived access token                      |
 | `HOMEAUTOMATION_URL`    | (Optional) Home Assistant base URL (default: `http://localhost:8123`) |
 
 **Example `.env**:**
 
 ```
-HOMEAUTOMAITON_TOKEN=your_home_assistant_token_here
+HOMEAUTOMATION_TOKEN=your_home_assistant_token_here
 HOMEAUTOMATION_URL=http://localhost:8123
 ```
 

--- a/home_assistant/homeautomation.py
+++ b/home_assistant/homeautomation.py
@@ -20,7 +20,7 @@ logger = logging.getLogger("listen-and-respond")
 logger.setLevel(logging.INFO)
 
 HOT_WORD = "hey casa"
-HOMEAUTOMAITON_TOKEN = os.getenv("HOMEAUTOMAITON_TOKEN")
+HOMEAUTOMATION_TOKEN = os.getenv("HOMEAUTOMATION_TOKEN")
 HOMEAUTOMATION_URL = os.getenv("HOMEAUTOMATION_URL", "http://localhost:8123")
 
 class SimpleAgent(Agent):
@@ -93,12 +93,12 @@ class SimpleAgent(Agent):
     @function_tool()
     async def list_devices(self) -> List[Dict[str, str]]:
         """List all available devices in the home automation system."""
-        if not HOMEAUTOMAITON_TOKEN:
+        if not HOMEAUTOMATION_TOKEN:
             self.session.say("Sorry, I can't list devices right now - the token is not configured")
             return []
 
         url = f"{HOMEAUTOMATION_URL}/api/states"
-        headers = {"Authorization": f"Bearer {HOMEAUTOMAITON_TOKEN}"}
+        headers = {"Authorization": f"Bearer {HOMEAUTOMATION_TOKEN}"}
 
         try:
             response = requests.get(url, headers=headers, timeout=10)
@@ -130,7 +130,7 @@ class SimpleAgent(Agent):
             entity_id: The ID of the device to control (e.g. 'light.kitchen')
             state: Either 'on' or 'off'
         """
-        if not HOMEAUTOMAITON_TOKEN:
+        if not HOMEAUTOMATION_TOKEN:
             self.session.say("Sorry, I can't control devices right now - the token is not configured")
             return
 
@@ -140,7 +140,7 @@ class SimpleAgent(Agent):
 
         # First get the device's friendly name
         url = f"{HOMEAUTOMATION_URL}/api/states/{entity_id}"
-        headers = {"Authorization": f"Bearer {HOMEAUTOMAITON_TOKEN}"}
+        headers = {"Authorization": f"Bearer {HOMEAUTOMATION_TOKEN}"}
         
         try:
             response = requests.get(url, headers=headers, timeout=10)


### PR DESCRIPTION
## Summary
- fix HOMEAUTOMATION_TOKEN name in `homeautomation.py`
- update documentation with the correct env var

## Testing
- `python -m py_compile home_assistant/homeautomation.py`


------
https://chatgpt.com/codex/tasks/task_e_684210dac3608324b7e0f4c24bea002c